### PR TITLE
Change: Bind minecraft events to server instead of player

### DIFF
--- a/app/Models/MinecraftAccount.php
+++ b/app/Models/MinecraftAccount.php
@@ -17,7 +17,7 @@ use Orchid\Screen\AsSource;
  * @property string         $status
  * @property Member         $member
  * @property Carbon|null    $whitelisted_at
- * @property Collection     $minecraftEvents
+ * @property Collection     $events
  * @property Carbon         $created_at
  * @property Carbon         $updated_at
  * @property Carbon|null    $deleted_at
@@ -40,7 +40,7 @@ class MinecraftAccount extends Model
         return $this->belongsTo(Member::class);
     }
 
-    public function minecraftEvents(): HasMany
+    public function events(): HasMany
     {
         return $this->hasMany(MinecraftEvent::class);
     }

--- a/app/Models/MinecraftEvent.php
+++ b/app/Models/MinecraftEvent.php
@@ -29,4 +29,9 @@ class MinecraftEvent extends Model
     {
         return $this->belongsTo(MinecraftAccount::class);
     }
+
+    public function server(): BelongsTo
+    {
+        return $this->belongsTo(Server::class);
+    }
 }

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -42,4 +42,9 @@ class Server extends Model
     {
         return $this->belongsToMany(Plugin::class);
     }
+
+    public function events(): HasMany
+    {
+        return $this->hasMany(MinecraftEvent::class);
+    }
 }

--- a/database/migrations/2023_12_18_193557_alter_minecraft_events_add_server.php
+++ b/database/migrations/2023_12_18_193557_alter_minecraft_events_add_server.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('minecraft_events', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('minecraft_account_id');
+        });
+
+        Schema::table('minecraft_events', function (Blueprint $table) {
+            $table->foreignId('server_id')->nullable()->constrained('servers');
+            $table->foreignId('minecraft_account_id')->nullable()->constrained('minecraft_accounts');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,5 +35,4 @@ Route::controller(DiscordAuthController::class)->group(function () {
 
 Route::controller(MinecraftApiController::class)->group(function () {
     Route::post('/mcevents/log', 'event_hook');
-    Route::post('/mcevents/global', 'global_event_hook');
 });

--- a/tests/Feature/EventApiTest.php
+++ b/tests/Feature/EventApiTest.php
@@ -47,7 +47,7 @@ class EventApiTest extends TestCase
 
     public function test_shutdown_event(): void
     {
-        $response = $this->post('/mcevents/global', [
+        $response = $this->post('/mcevents/log', [
             'event_type'    => 'shutdown',
             'api_token'     => $this->server->api_key
         ]);
@@ -55,7 +55,8 @@ class EventApiTest extends TestCase
         $response->assertStatus(200);
 
         $this->assertDatabaseHas('minecraft_events', [
-            'event_type'            => 'shutdown',
+            'event_type'    => 'shutdown',
+            'server_id'     => $this->server->id
         ]);
     }
 }


### PR DESCRIPTION
This moves the primary relationship of the `minecraft_events` table from `minecraft_accounts` to `servers`. This will allow us to query better, as well as making it easier to insert global non-player events.